### PR TITLE
Catalina - Changed to layout 21 to use the internal mic. The jack 3.5…

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -249,7 +249,7 @@
 		<dict>
 			<key>PciRoot(0x0)/Pci(0x1b,0x0)</key>
 			<dict>
-				<key>layout-id</key>
+				<key>#layout-id</key>
 				<data>AwAAAA==</data>
 			</dict>
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>
@@ -1203,7 +1203,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>-v keepsyms=1 debug=0x100 alcid=3 -wegnoegpu sw_panic=1</string>
+				<string>-v keepsyms=1 debug=0x100 alcid=21 -wegnoegpu sw_panic=1</string>
 				<key>run-efi-updater</key>
 				<string>No</string>
 				<key>csr-active-config</key>


### PR DESCRIPTION
…mm won't be fixed.
---

Resolved #4 

---
- If you used layout `3`, you can see the in-line port (jack 3.5mm) and an internal mic, but both won't work.
- If you used layout `21` or `28`, you only see the internal mic, but it works well. Because I don't use the jack 3.5mm anymore, so it :x: **won't be my priority to resolve this** :x:.
# Thanks
[Acidanthera](https://github.com/acidanthera) and their work on [AppleALC](https://github.com/acidanthera/AppleALC) and [Lilu](https://github.com/acidanthera/Lilu)